### PR TITLE
Ignores package-lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 .DS_Store
+package-lock.json


### PR DESCRIPTION
Ignores lock file to prevent getting stuck with old versions.