### PR TITLE
Adds field options for Google Tag Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,21 @@
+# 1.3.0 - 2020-07-01
+
+- Adds Google Tag Manager support.
+
 # 1.2.4
 
-Updates eslint configuration to use `eslint-config-apostrophe`.
+- Updates eslint configuration to use `eslint-config-apostrophe`.
 
 # 1.2.3
 
-Building on 1.2.2, we also should not output the robots meta tag at all if neither box was checked, although there is no harm in an empty one.
+- Building on 1.2.2, we also should not output the robots meta tag at all if neither box was checked, although there is no harm in an empty one.
 
 # 1.2.2
 
-Prior to this release there were separate checkboxes for "index, follow", "noindex" and "nofollow", even though checkboxes are nonexclusive, so it was possible to pick "index, follow" and "noindex" simultaneously — an invalid combination. Beginning with this release, there is no "index, follow" option because that is the default behavior of Google and never has to be explicitly chosen. If you want your page to be crawled and indexed normally, just leave the "noindex" and "nofollow" checkboxes alone.
+- Prior to this release there were separate checkboxes for "index, follow", "noindex" and "nofollow", even though checkboxes are nonexclusive, so it was possible to pick "index, follow" and "noindex" simultaneously — an invalid combination. Beginning with this release, there is no "index, follow" option because that is the default behavior of Google and never has to be explicitly chosen. If you want your page to be crawled and indexed normally, just leave the "noindex" and "nofollow" checkboxes alone.
 
-However, for bc reasons, if you are already using this module you may note that "index, follow" is explicitly output on pages for which you haven't edited the settings yet. That's fine and will have no ill effects. The only case you might want to look into is anywhere you chose an invalid combination of options as described above.
+- However, for bc reasons, if you are already using this module you may note that "index, follow" is explicitly output on pages for which you haven't edited the settings yet. That's fine and will have no ill effects. The only case you might want to look into is anywhere you chose an invalid combination of options as described above.
 
 # 1.2.1
 
-The hard limits placed on seoTitle and seoDescription in version 1.2.0 are now just warnings, but still pop up when appropriate, calling attention to the fact that you are outside Google's guidelines. This is helpful if you are in no rush to shorten your `title` tags.
+- The hard limits placed on seoTitle and seoDescription in version 1.2.0 are now just warnings, but still pop up when appropriate, calling attention to the fact that you are outside Google's guidelines. This is helpful if you are in no rush to shorten your `title` tags.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # apostrophe-seo
 
-SEO for [ApostropheCMS](http://apostrophecms.org/).
+SEO configuration for [ApostropheCMS](https://apostrophecms.com/).
 
 Add useful meta fields to all pages and pieces.
 
@@ -70,7 +70,7 @@ Add the following `include`  to your `<head></head>` in `layout.html` that all o
 {% endblock %}
 ```
 
-**The Canonical Link field** on a page or piece allows an editor to select another page that search engines should understand to be the primary version of that page or piece. [As described on Moz.com](https://moz.com/learn/seo/canonicalization):
+**The canonical link field** on a page or piece allows an editor to select another page that search engines should understand to be the primary version of that page or piece. [As described on Moz.com](https://moz.com/learn/seo/canonicalization):
 
 > A canonical tag (aka "rel canonical") is a way of telling search engines that a specific URL represents the master copy of a page. Using the canonical tag prevents problems caused by identical or "duplicate" content appearing on multiple URLs. Practically speaking, the canonical tag tells search engines which version of a URL you want to appear in search results.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Finally, you may only want to use Google Tag Manager for all analytics and site 
 
 ### 3. Updating views
 
-Add the following `include`  to your `<head></head>` in `layout.html` that all of your pages extend, or to `outerLayout.html` if you have one in `apostrophe-templates/views/`. This will output the meta tags needed for SEO and Google Analytics/Verification configuration. The `robots` meta tag will only be included if the related field is set to something other than `index,follow` on the page-level (browsers already default to that).
+Add the following `include`  to your `<head></head>` in `layout.html` that all of your pages extend, or to `outerLayout.html` if you have one in `apostrophe-templates/views/`. This will output the meta tags needed for SEO and Google Analytics/Verification configuration.
 
 ```nunjucks
 {% if data.piece %}

--- a/README.md
+++ b/README.md
@@ -45,9 +45,8 @@ If you would like to configure additional fields to allow an editor to add a Goo
 Finally, you may only want to use Google Tag Manager for all analytics and site verification needs. Set `seoTagMangerOnly: true` in `apostrophe-global` to do this. Doing so will override the other options, making their presence irrelevant if also set.
 
 ### 3. Updating views
-If you would like to configure additional fields to allow an editor to add a Google Analytics tracking ID and a Google site verification ID you can do so by setting `seoGoogleFields: true` in `apostrophe-global` in your project.
 
-Add the following include to your `<head></head>` in `layout.html` that all of your pages extend, or to `outerLayout.html` if you have one in `apostrophe-templates/views/`. This will output the meta tags needed for SEO and Google Analytics/Verification configuration. The robots meta tag will only be shown if set to something other than `index,follow` (browser already defaults to that).
+Add the following `include`  to your `<head></head>` in `layout.html` that all of your pages extend, or to `outerLayout.html` if you have one in `apostrophe-templates/views/`. This will output the meta tags needed for SEO and Google Analytics/Verification configuration. The `robots` meta tag will only be included if the related field is set to something other than `index,follow` on the page-level (browsers already default to that).
 
 ```nunjucks
 {% if data.piece %}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ module.exports = {
 };
 ```
 
-If you would like to configure additional fields to allow an editor to add a Google Analytics tracking ID and a Google site verification ID you can do so by setting `seoGoogleFields: true` in `apostrophe-global` in your project.
+### Adding global fields for analytics
+
+If you would like to configure additional fields to allow an editor to add a Google Analytics tracking ID and a Google site verification ID you can do so by setting `seoGoogleFields: true` in `apostrophe-global` in your project. Add `seoGoogleTagManager: true` to also add a field for the Google Tag Manager ID (`seoGoogleFields` must also be `true` in this case).
+
+Finally, you may only want to use Google Tag Manager for all analytics and site verification needs. Set `seoTagMangerOnly: true` in `apostrophe-global` to do this. Doing so will override the other options, making their presence irrelevant if also set.
+
+### Implementing fields in the layout
 
 Add the following include to your `<head></head>` in `layout.html` that all of your pages extend, or to `outerLayout.html` if you have one in `apostrophe-templates/views/`. This will output the meta tags needed for SEO and Google Analytics/Verification configuration.
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 module.exports = {
+  extend: 'apostrophe-module',
   moogBundle: {
     modules: [
       'apostrophe-seo-doc-type-manager',
@@ -10,5 +11,18 @@ module.exports = {
       'apostrophe-seo-users'
     ],
     directory: 'lib/modules'
+  },
+  construct: function (self, options) {
+    self.prependSnippets = () => {
+      self.apos.templates.prepend('body', (req) => {
+        return self.partial('body-gtm', {});
+      });
+      self.apos.templates.append('head', (req) => {
+        return self.partial('head-gtm', {});
+      });
+    };
+  },
+  afterConstruct: (self) => {
+    self.prependSnippets();
   }
 };

--- a/lib/modules/apostrophe-seo-global/index.js
+++ b/lib/modules/apostrophe-seo-global/index.js
@@ -42,15 +42,10 @@ module.exports = {
         label: 'Google IDs',
         fields: [
           'seoGoogleTrackingId',
-<<<<<<< HEAD
           'seoGoogleVerificationId',
           'seoGoogleTagManager'
-        ]
-=======
-          'seoGoogleVerificationId'
         ],
         last: true
->>>>>>> master
       }
     ].concat(options.arrangeFields || []);
   }

--- a/lib/modules/apostrophe-seo-global/index.js
+++ b/lib/modules/apostrophe-seo-global/index.js
@@ -6,7 +6,7 @@ module.exports = {
       name: 'seoGoogleTagManager',
       label: 'Google Tag Manager ID',
       type: 'string',
-      help: 'Account ID provided by Google for Google Tag Manager.'
+      help: 'Container ID provided in Google Tag Manager (e.g., GTM-RPCVDTN).'
     };
 
     let seoGoogleFields;

--- a/lib/modules/apostrophe-seo-global/index.js
+++ b/lib/modules/apostrophe-seo-global/index.js
@@ -2,20 +2,38 @@ module.exports = {
   improve: 'apostrophe-global',
   seo: false,
   construct: (self, options) => {
-    const seoGoogleFields = options.seoGoogleFields ? [
-      {
-        name: 'seoGoogleTrackingId',
-        label: 'Google Tracking ID',
-        type: 'string',
-        help: 'Tracking ID provided by Google for Google Analytics.'
-      },
-      {
-        name: 'seoGoogleVerificationId',
-        label: 'Google Verification ID',
-        type: 'string',
-        help: 'Verification ID provided by Google for the HTML meta tag verification option.'
+    const tagManagerFields = {
+      name: 'seoGoogleTagManager',
+      label: 'Google Tag Manager ID',
+      type: 'string',
+      help: 'Account ID provided by Google for Google Tag Manager.'
+    };
+
+    let seoGoogleFields;
+
+    if (options.seoTagMangerOnly) {
+      seoGoogleFields = [tagManagerFields];
+    } else if (options.seoGoogleFields) {
+      seoGoogleFields = [
+        {
+          name: 'seoGoogleTrackingId',
+          label: 'Google Tracking ID',
+          type: 'string',
+          help: 'Tracking ID provided by Google for Google Analytics.'
+        },
+        {
+          name: 'seoGoogleVerificationId',
+          label: 'Google Verification ID',
+          type: 'string',
+          help: 'Verification ID provided by Google for the HTML meta tag verification option.'
+        }
+      ];
+
+      if (options.seoGoogleTagManager) {
+        seoGoogleFields.push(tagManagerFields);
       }
-    ] : [];
+    }
+
     options.addFields = options.addFields.concat(seoGoogleFields || []);
 
     options.arrangeFields = [
@@ -24,7 +42,8 @@ module.exports = {
         label: 'Google IDs',
         fields: [
           'seoGoogleTrackingId',
-          'seoGoogleVerificationId'
+          'seoGoogleVerificationId',
+          'seoGoogleTagManager'
         ]
       }
     ].concat(options.arrangeFields || []);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-seo",
-  "version": "1.2.4",
+  "version": "1.3.0",
   "description": "SEO for ApostropheCMS",
   "main": "index.js",
   "scripts": {

--- a/views/body-snippet.html
+++ b/views/body-snippet.html
@@ -1,0 +1,8 @@
+{% if data.global.seoGoogleTagManager %}
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe src="https://www.googletagmanager.com/ns.html?id={{data.global.seoGoogleTagManager}}"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
+{% endif %}

--- a/views/head-snippet.html
+++ b/views/head-snippet.html
@@ -1,0 +1,9 @@
+{% if data.global.seoGoogleTagManager %}
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{data.global.seoGoogleTagManager}}');</script>
+  <!-- End Google Tag Manager -->
+{% endif %}


### PR DESCRIPTION
This is the start of an update to add the ability to set up Google Tag Manager in addition to or instead of the other Google fields.

One reason: Tag Manager can be used to implement Google Analytics and other SEO tools. Second reason: This module optionally creates a global field group called "Google IDs," which is the best (right) place for a Tag Manager field to be. I'm not sure if there's a way to add a field to this module-created field group on the project level.

I'll go ahead with the template implementation if folks think it's worth doing. I think I'd be using `beforeMain` for the noscript GTM tag, but that could be tricky to avoid project breakages (maybe `super()` would be enough?).