### PR TITLE
Flag to set canonical link on all pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ const apos = require('apostrophe')({
 
 Option | Type | Default | Description
 ---|---|---|---
-canonical | Boolean | `null` | Enables a canonical tag on every page set to `data._url`.
+canonical | Boolean | `null` | Enables a canonical tag on every page set to `data.page._url` or `data.piece._url`.
 
 If you choose to disable fields for a piece or page you can do so by setting `seo: false` on the module. `apostrophe-files`, `apostrophe-global`, `apostrophe-groups`, `apostrophe-images`, `apostrophe-users` have `seo: false` configured by default.
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ const apos = require('apostrophe')({
 });
 ```
 
+### Options
+
+Option | Type | Default | Description
+---|---|---|---
+canonical | Boolean | `null` | Enables a canonical tag on every page set to `data._url`.
+
 If you choose to disable fields for a piece or page you can do so by setting `seo: false` on the module. `apostrophe-files`, `apostrophe-global`, `apostrophe-groups`, `apostrophe-images`, `apostrophe-users` have `seo: false` configured by default.
 
 ```js

--- a/views/view.html
+++ b/views/view.html
@@ -16,6 +16,15 @@
 <meta name="google-site-verification" content="{{ data.global.seoGoogleVerificationId }}" />
 {% endif %}
 
+{% if apos.seo and apos.seo.getOption('canonical') %}
+  {% if data.piece %}
+    {% set seoUrl = data.piece._url %}
+  {% elif data.page %}
+    {% set seoUrl = data.page._url %}
+  {% endif %}
+  <link rel="canonical" href="{{ seoUrl }}" />
+{% endif %}
+
 {% if data.global.seoGoogleTrackingId %}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ data.global.seoGoogleTrackingId }}"></script>

--- a/views/view.html
+++ b/views/view.html
@@ -16,7 +16,7 @@
 <meta name="google-site-verification" content="{{ data.global.seoGoogleVerificationId }}" />
 {% endif %}
 
-{% if apos.seo and apos.seo.getOption('canonical') %}
+{% if apos.seo and apos.modules['apostrophe-seo'] %}
   {% if data.piece %}
     {% set seoUrl = data.piece._url %}
   {% elif data.page %}


### PR DESCRIPTION
Draft implementation requires that `alias` be set to `seo` on the module which is a bc break.

Solves #19 