### PR TITLE
Add Canonical Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,6 @@ Add the following include to your `<head></head>` in `layout.html` that all of y
 {% endblock %}
 ```
 
-Canonical Link allows you to select one main page that search engines should be pointed to for similar content.
+The Canonical Link field on a page or piece allows an editor to select another page that search engines should understand to be the primary version of that page or piece. [As described on Moz.com](https://moz.com/learn/seo/canonicalization):
+
+> A canonical tag (aka "rel canonical") is a way of telling search engines that a specific URL represents the master copy of a page. Using the canonical tag prevents problems caused by identical or "duplicate" content appearing on multiple URLs. Practically speaking, the canonical tag tells search engines which version of a URL you want to appear in search results.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ module.exports = {
 
 If you would like to configure additional fields to allow an editor to add a Google Analytics tracking ID and a Google site verification ID you can do so by setting `seoGoogleFields: true` in `apostrophe-global` in your project.
 
-Add the following include to your `<head></head>` in `layout.html` that all of your pages extend, or to `outerLayout.html` if you have one in `apostrophe-templates/views/`. This will output the meta tags needed for SEO and Google Analytics/Verification configuration. By default the robots meta tag is set to `index,follow`. 
+Add the following include to your `<head></head>` in `layout.html` that all of your pages extend, or to `outerLayout.html` if you have one in `apostrophe-templates/views/`. This will output the meta tags needed for SEO and Google Analytics/Verification configuration. The robots meta tag will only be shown if set to something other than `index,follow` (browser already defaults to that).
 
 ```nunjucks
 {% if data.piece %}

--- a/README.md
+++ b/README.md
@@ -59,3 +59,5 @@ Add the following include to your `<head></head>` in `layout.html` that all of y
   {% include "apostrophe-seo:view.html" %}
 {% endblock %}
 ```
+
+Canonical Link allows you to select one main page that search engines should be pointed to for similar content.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ module.exports = {
 
 If you would like to configure additional fields to allow an editor to add a Google Analytics tracking ID and a Google site verification ID you can do so by setting `seoGoogleFields: true` in `apostrophe-global` in your project.
 
-Add the following include to your `<head></head>` in `layout.html` that all of your pages extend, or to `outerLayout.html` if you have one in `apostrophe-templates/views/`. This will output the meta tags needed for SEO and Google Analytics/Verification configuration.
+Add the following include to your `<head></head>` in `layout.html` that all of your pages extend, or to `outerLayout.html` if you have one in `apostrophe-templates/views/`. This will output the meta tags needed for SEO and Google Analytics/Verification configuration. By default the robots meta tag is set to `index,follow`. 
 
 ```nunjucks
 {% if data.piece %}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 module.exports = {
   moogBundle: {
     modules: [
-      'apostrophe-seo-doc-type-manager',
+      'apostrophe-seo-custom-pages',
       'apostrophe-seo-files',
       'apostrophe-seo-images',
       'apostrophe-seo-global',

--- a/lib/modules/apostrophe-seo-custom-pages/index.js
+++ b/lib/modules/apostrophe-seo-custom-pages/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  improve: 'apostrophe-doc-type-manager',
+  improve: 'apostrophe-custom-pages',
   beforeConstruct: (self, options) => {
     if (options.seo !== false) {
       options.addFields = [

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -18,7 +18,7 @@ module.exports = {
         {
           name: 'seoRobots',
           label: 'Robots Tag',
-          htmlHelp: '<i class="fa fa-info-circle"></i> <a href=https://moz.com/learn/seo/robots-meta-directives data-toggle="tooltip" target="new_window" title="Learn More About Robots Meta Tag">Learn More</a>',
+          htmlHelp: 'Search engine indexing setting <a href=https://moz.com/learn/seo/robots-meta-directives data-toggle="tooltip" target="new_window" title="Learn More About Robots Meta Tag">Learn more about these options</a>',
           type: 'checkboxes',
           choices: [
             {

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -8,7 +8,7 @@ module.exports = {
           label: 'Title',
           type: 'string',
           max: 60,
-          help: 'Defines the title of the page in search results or on the page\'s tab. It should be under 60 characters.'
+          help: 'Defines the title of the page in search results or on the page\'s tab. It should be <a href="https://moz.com/learn/seo/title-tag" target="_blank">under 60 characters</a>.'
         },
         {
           name: 'seoDescription',
@@ -16,7 +16,7 @@ module.exports = {
           type: 'string',
           min: 50,
           max: 300,
-          help: 'A short and accurate summary of the content of the page used in search results. It should be between 50-300 characters.'
+          htmlHelp: 'A short and accurate summary of the content of the page used in search results. It should be <a href="https://moz.com/learn/seo/meta-description" target="_blank">between 50-160 characters</a>.'
         }
       ].concat(options.addFields || []);
 

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -14,6 +14,20 @@ module.exports = {
           label: 'Description',
           type: 'string',
           help: 'A short and accurate summary of the content of the page used in search results.'
+        },
+        {
+          name: '_seoCanonical',
+          label: 'Canonical Link',
+          type: 'joinByOne',
+          withType: 'apostrophe-page',
+          idField: 'pageId',
+          help: 'Is there a main version of this page that search engines should direct to?',
+          filters: {
+            projection: {
+              title: 1,
+              slug: 1
+            }
+          }
         }
       ].concat(options.addFields || []);
 
@@ -23,7 +37,8 @@ module.exports = {
           label: 'SEO',
           fields: [
             'seoTitle',
-            'seoDescription'
+            'seoDescription',
+            '_seoCanonical'
           ],
           last: true
         }

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -8,7 +8,7 @@ module.exports = {
           label: 'Title',
           type: 'string',
           max: 60,
-          help: 'Defines the title of the page in search results or on the page\'s tab. It should be <a href="https://moz.com/learn/seo/title-tag" target="_blank">under 60 characters</a>.'
+          htmlHelp: 'Defines the title of the page in search results or on the page\'s tab. It should be <a href="https://moz.com/learn/seo/title-tag" target="_blank">under 60 characters</a>.'
         },
         {
           name: 'seoDescription',

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -14,7 +14,9 @@ module.exports = {
           name: 'seoDescription',
           label: 'Description',
           type: 'string',
-          help: 'A short and accurate summary of the content of the page used in search results.'
+          min: 50,
+          max: 300,
+          htmlHelp: 'A short and accurate summary of the content of the page used in search results. It should be <a href="https://moz.com/learn/seo/meta-description" target="_blank">between 50-160 characters</a>.'
         },
         {
           name: '_seoCanonical',
@@ -23,8 +25,6 @@ module.exports = {
           withType: 'apostrophe-page',
           idField: 'pageId',
           help: 'Is there a main version of this page that search engines should direct to?',
-          min: 50,
-          max: 300,
           filters: {
             projection: {
               title: 1,

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -18,22 +18,23 @@ module.exports = {
         {
           name: 'seoRobots',
           label: 'Robots Tag',
+          htmlHelp: '<i class="fa fa-info-circle"></i> <a href=https://moz.com/learn/seo/robots-meta-directives data-toggle="tooltip" target="new_window" title="Learn More About Robots Meta Tag">Learn More</a>',
           type: 'checkboxes',
           choices: [
             {
-              label: 'Follow',
+              label: 'Crawl All Links (Follow)',
               value: 'follow'
             },
             {
-              label: 'Index',
+              label: 'Index Page (Index)',
               value: 'index'
             },
             {
-              label: 'No-Follow',
+              label: 'Do not crawl links on page (No Follow)',
               value: 'nofollow'
             },
             {
-              label: 'No-Index',
+              label: 'Stop Indexing Page (No Index)',
               value: 'noindex'
             }
           ]

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -24,7 +24,7 @@ module.exports = {
           choices: [
             {
               label: 'Default (Index,Follow)',
-              value: 'index,folow'
+              value: 'index,follow'
             },
             {
               label: 'Do not crawl links on page (No Follow)',

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -19,7 +19,6 @@ module.exports = {
           name: 'seoRobots',
           label: 'Robots Tag',
           type: 'checkboxes',
-          def: ['index, follow'],
           choices: [
             {
               label: 'Follow',

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -23,7 +23,7 @@ module.exports = {
           def: 'index,follow',
           choices: [
             {
-              label: 'Default (Index,Follow)'
+              label: 'Default (Index,Follow)',
               value: 'index,folow'
             },
             {

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -7,13 +7,16 @@ module.exports = {
           name: 'seoTitle',
           label: 'Title',
           type: 'string',
-          help: 'Defines the title of the page in search results or on the page\'s tab.'
+          max: 60,
+          help: 'Defines the title of the page in search results or on the page\'s tab. It should be under 60 characters.'
         },
         {
           name: 'seoDescription',
           label: 'Description',
           type: 'string',
-          help: 'A short and accurate summary of the content of the page used in search results.'
+          min: 50,
+          max: 300,
+          help: 'A short and accurate summary of the content of the page used in search results. It should be between 50-300 characters.'
         }
       ].concat(options.addFields || []);
 

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -20,14 +20,11 @@ module.exports = {
           label: 'Robots Tag',
           htmlHelp: 'Search engine indexing setting <a href=https://moz.com/learn/seo/robots-meta-directives data-toggle="tooltip" target="new_window" title="Learn More About Robots Meta Tag">Learn more about these options</a>',
           type: 'checkboxes',
+          def: 'index,follow',
           choices: [
             {
-              label: 'Crawl All Links (Follow)',
-              value: 'follow'
-            },
-            {
-              label: 'Index Page (Index)',
-              value: 'index'
+              label: 'Default (Index,Follow)'
+              value: 'index,folow'
             },
             {
               label: 'Do not crawl links on page (No Follow)',

--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -14,7 +14,31 @@ module.exports = {
           label: 'Description',
           type: 'string',
           help: 'A short and accurate summary of the content of the page used in search results.'
-        }
+        },
+        {
+          name: 'seoRobots',
+          label: 'Robots Tag',
+          type: 'checkboxes',
+          def: ['index, follow'],
+          choices: [
+            {
+              label: 'Follow',
+              value: 'follow'
+            },
+            {
+              label: 'Index',
+              value: 'index'
+            },
+            {
+              label: 'No-Follow',
+              value: 'nofollow'
+            },
+            {
+              label: 'No-Index',
+              value: 'noindex'
+            }
+          ]
+        },
       ].concat(options.addFields || []);
 
       options.arrangeFields = [
@@ -23,7 +47,8 @@ module.exports = {
           label: 'SEO',
           fields: [
             'seoTitle',
-            'seoDescription'
+            'seoDescription',
+            'seoRobots'
           ],
           last: true
         }

--- a/views/view.html
+++ b/views/view.html
@@ -12,7 +12,7 @@
   <meta name="description" content="{{ seoDescription }}" />
 {% endif %}
 
-{% if data.page.seoRobots and not 'index,follow' %}
+{% if data.page.seoRobots %}
   <meta name="robots" content="{{ data.page.seoRobots }}" />
 {% endif %}
 

--- a/views/view.html
+++ b/views/view.html
@@ -16,6 +16,10 @@
 <meta name="google-site-verification" content="{{ data.global.seoGoogleVerificationId }}" />
 {% endif %}
 
+{% if data.page._seoCanonical  %}
+	<link rel="canonical" href="{{data.baseUrl}}{{data.page._seoCanonical.slug }}" />
+{% endif %}
+
 {% if data.global.seoGoogleTrackingId %}
 <!-- Global site tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ data.global.seoGoogleTrackingId }}"></script>

--- a/views/view.html
+++ b/views/view.html
@@ -21,7 +21,7 @@
 {% endif %}
 
 {% if data.page._seoCanonical  %}
-	<link rel="canonical" href="{{data.baseUrl}}{{data.page._seoCanonical.slug }}" />
+	<link rel="canonical" href="{{data.baseUrl}}{{data.page._seoCanonical._url }}" />
 {% endif %}
 
 {% if data.global.seoGoogleTrackingId %}

--- a/views/view.html
+++ b/views/view.html
@@ -12,7 +12,7 @@
   <meta name="description" content="{{ seoDescription }}" />
 {% endif %}
 
-{% if data.page.seoRobots %}
+{% if data.page.seoRobots and not 'index,follow' %}
   <meta name="robots" content="{{ data.page.seoRobots }}" />
 {% endif %}
 

--- a/views/view.html
+++ b/views/view.html
@@ -12,6 +12,10 @@
   <meta name="description" content="{{ seoDescription }}" />
 {% endif %}
 
+{% if data.page.seoRobots %}
+  <meta name="robots" content="{{ data.page.seoRobots }}" />
+{% endif %}
+
 {% if data.global.seoGoogleVerificationId %}
 <meta name="google-site-verification" content="{{ data.global.seoGoogleVerificationId }}" />
 {% endif %}

--- a/views/view.html
+++ b/views/view.html
@@ -21,7 +21,7 @@
 {% endif %}
 
 {% if data.page._seoCanonical  %}
-	<link rel="canonical" href="{{data.baseUrl}}{{data.page._seoCanonical._url }}" />
+	<link rel="canonical" href="{{data.page._seoCanonical._url }}" />
 {% endif %}
 
 {% if data.global.seoGoogleTrackingId %}


### PR DESCRIPTION
This code adds a Canonical Link to the Page settings that will allow users to link to similar content that the search engine should be pointed to instead. 

Closes #28 