### PR TITLE
soft rather than hard limits, because customers who had this module b…

### DIFF
--- a/lib/modules/apostrophe-seo-doc-type-manager/index.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/index.js
@@ -7,15 +7,15 @@ module.exports = {
           name: 'seoTitle',
           label: 'Title',
           type: 'string',
-          max: 60,
+          seoSoftMax: 60,
           htmlHelp: 'Defines the title of the page in search results or on the page\'s tab. It should be <a href="https://moz.com/learn/seo/title-tag" target="_blank">under 60 characters</a>.'
         },
         {
           name: 'seoDescription',
           label: 'Description',
           type: 'string',
-          min: 50,
-          max: 300,
+          seoSoftMin: 50,
+          seoSoftMax: 160,
           htmlHelp: 'A short and accurate summary of the content of the page used in search results. It should be <a href="https://moz.com/learn/seo/meta-description" target="_blank">between 50-160 characters</a>.'
         },
         {

--- a/lib/modules/apostrophe-seo-doc-type-manager/public/css/user.less
+++ b/lib/modules/apostrophe-seo-doc-type-manager/public/css/user.less
@@ -1,0 +1,22 @@
+// Pattern closely following that for apos schema errors
+
+.apos-seo-soft-limit
+{
+  input {
+    &:first-of-type:not(.apos-field-input-radio) {
+      // Used for warnings elsewhere in apostrophe
+      .apos-glow(@apos-gold);
+    }
+  }
+  label {
+    position: relative;
+    &:first-of-type {
+      color: @apos-gold;
+    }
+    &:first-of-type::after {
+      margin-left: 10px;
+      content: "(" attr(data-apos-seo-soft-limit-message) ")";
+      color: inherit;
+    }
+  }
+}

--- a/lib/modules/apostrophe-seo-doc-type-manager/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/public/js/editor-modal.js
@@ -5,7 +5,6 @@ $(function() {
       if (err) {
         return callback(err);
       }
-      console.log('hello');
       if (field.seoSoftMin || field.seoSoftMax) {
         $field.on('textchange', update);
         $field.on('change', update);

--- a/lib/modules/apostrophe-seo-doc-type-manager/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/public/js/editor-modal.js
@@ -11,9 +11,9 @@ $(function() {
         function update() {
           var len = $field.val().length;
           if (len && (len < field.seoSoftMin)) {
-            warning('Fewer than ' + field.seoSoftMin + ' characters');
+            warning('You have not reached the recommended minimum of  ' + field.seoSoftMin + ' characters');
           } else if (len && (len > field.seoSoftMax)) {
-            warning('More than ' + field.seoSoftMax + ' characters');
+            warning('You have exceeded the recommended maximum of ' + field.seoSoftMax + ' characters');
           } else {
             clearWarning();
           }

--- a/lib/modules/apostrophe-seo-doc-type-manager/public/js/editor-modal.js
+++ b/lib/modules/apostrophe-seo-doc-type-manager/public/js/editor-modal.js
@@ -1,0 +1,39 @@
+$(function() {
+  var superPopulate = apos.schemas.fieldTypes.string.populate;
+  apos.schemas.fieldTypes.string.populate = function(data, name, $field, $el, field, callback) {
+    return superPopulate(data, name, $field, $el, field, function(err) {
+      if (err) {
+        return callback(err);
+      }
+      console.log('hello');
+      if (field.seoSoftMin || field.seoSoftMax) {
+        $field.on('textchange', update);
+        $field.on('change', update);
+        function update() {
+          var len = $field.val().length;
+          if (len && (len < field.seoSoftMin)) {
+            warning('Fewer than ' + field.seoSoftMin + ' characters');
+          } else if (len && (len > field.seoSoftMax)) {
+            warning('More than ' + field.seoSoftMax + ' characters');
+          } else {
+            clearWarning();
+          }
+        }
+        // Follow the pattern used for apos schema errors
+        function warning(s) {
+          var $fieldset = $field.closest('[data-name]');
+          var $label = $fieldset.find('label:first');
+          $fieldset.addClass('apos-seo-soft-limit');
+          $label.attr('data-apos-seo-soft-limit-message', s);
+        }
+        function clearWarning() {
+          var $fieldset = $field.closest('[data-name]');
+          var $label = $fieldset.find('label:first');
+          $fieldset.removeClass('apos-seo-soft-limit');
+          $label.removeAttr('data-apos-seo-soft-limit-message');
+        }
+      }
+      return callback(null);
+    });
+  };
+});


### PR DESCRIPTION
…efore the 60 character limit have a huge mess to clean up otherwise, and because just because google does not show the title in its entirety does not mean they do not index it, etc.

<img width="596" alt="Screen Shot 2020-01-13 at 5 07 00 PM" src="https://user-images.githubusercontent.com/32125/72296383-71daa380-3627-11ea-89b9-011b2859bdf1.png">

(Color used is apos-gold which is specified elsewhere for warnings, CSS pattern is closely based on the pattern for errors. I namespaced names to avoid conflict with any future standard implementation of soft limits)