### PR TITLE
disable seo by default for i18n-static

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   moogBundle: {
     modules: [
       'apostrophe-seo-doc-type-manager',
+      'apostrophe-seo-i18n-static',
       'apostrophe-seo-custom-pages',
       'apostrophe-seo-files',
       'apostrophe-seo-images',

--- a/lib/modules/apostrophe-seo-i18n-static/index.js
+++ b/lib/modules/apostrophe-seo-i18n-static/index.js
@@ -1,0 +1,4 @@
+module.exports = {
+  improve: 'apostrophe-i18n-static',
+  seo: false
+};


### PR DESCRIPTION
Noticed this when working with the `i18n-static` module. Seemed reasonable that seo should be disabled by default for that module as well as there's really no "page" for individual keys.