### PR TITLE
including an improvement in a bundle always triggers that improvement…

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ module.exports = {
   moogBundle: {
     modules: [
       'apostrophe-seo-doc-type-manager',
-      'apostrophe-seo-i18n-static',
       'apostrophe-seo-custom-pages',
       'apostrophe-seo-files',
       'apostrophe-seo-images',

--- a/lib/modules/apostrophe-seo-i18n-static/index.js
+++ b/lib/modules/apostrophe-seo-i18n-static/index.js
@@ -1,4 +1,0 @@
-module.exports = {
-  improve: 'apostrophe-i18n-static',
-  seo: false
-};


### PR DESCRIPTION
…, but apostrophe-i18n-static might not exist in the project, causing an error. That module should just ship with "seo: false" set instead