### PR TITLE
Fixes template partial names

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,10 @@ module.exports = {
   construct: function (self, options) {
     self.prependSnippets = () => {
       self.apos.templates.prepend('body', (req) => {
-        return self.partial('body-gtm', {});
+        return self.partial('body-snippet', {});
       });
       self.apos.templates.append('head', (req) => {
-        return self.partial('head-gtm', {});
+        return self.partial('head-snippet', {});
       });
     };
   },


### PR DESCRIPTION
Actual files are visible here: https://github.com/apostrophecms/apostrophe-seo/tree/main/views. These were the old names.