### PR TITLE
Add core peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,38 @@
-# 1.4.0 - 2021-02-11
+# Changelog
+
+## Unreleased
+- Adds a peer dependency for `apostrophe^2.116.1` to support the latest SEO page scan feature.
+
+## 1.4.0 - 2021-02-11
 - Adds the SEO page scan feature
 
-# 1.3.3 - 2020-11-04
+## 1.3.3 - 2020-11-04
 - Updates `eslint` to `^7.1.0`
 
-# 1.3.2 - 2020-10-26
+## 1.3.2 - 2020-10-26
 - Republishing to address npm issue. No changes.
 
-# 1.3.1 - 2020-10-07
+## 1.3.1 - 2020-10-07
 - Adds a note about setting the `baseUrl` option in the README.
 
-# 1.3.0 - 2020-07-01
+## 1.3.0 - 2020-07-01
 
 - Adds Google Tag Manager support.
 
-# 1.2.4
+## 1.2.4
 
 - Updates eslint configuration to use `eslint-config-apostrophe`.
 
-# 1.2.3
+## 1.2.3
 
 - Building on 1.2.2, we also should not output the robots meta tag at all if neither box was checked, although there is no harm in an empty one.
 
-# 1.2.2
+## 1.2.2
 
 - Prior to this release there were separate checkboxes for "index, follow", "noindex" and "nofollow", even though checkboxes are nonexclusive, so it was possible to pick "index, follow" and "noindex" simultaneously — an invalid combination. Beginning with this release, there is no "index, follow" option because that is the default behavior of Google and never has to be explicitly chosen. If you want your page to be crawled and indexed normally, just leave the "noindex" and "nofollow" checkboxes alone.
 
 - However, for bc reasons, if you are already using this module you may note that "index, follow" is explicitly output on pages for which you haven't edited the settings yet. That's fine and will have no ill effects. The only case you might want to look into is anywhere you chose an invalid combination of options as described above.
 
-# 1.2.1
+## 1.2.1
 
 - The hard limits placed on seoTitle and seoDescription in version 1.2.0 are now just warnings, but still pop up when appropriate, calling attention to the fact that you are outside Google's guidelines. This is helpful if you are in no rush to shorten your `title` tags.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "url": "https://github.com/apostrophecms/apostrophe-seo/issues"
   },
   "homepage": "https://github.com/apostrophecms/apostrophe-seo#readme",
+  "peerDependencies": {
+    "apostrophe": "^2.116.1"
+  },
   "devDependencies": {
     "eslint": "^7.1.0",
     "eslint-config-apostrophe": "^3.1.0",


### PR DESCRIPTION
The new page scan template uses the `__ns` template helper. That wasn't supported until `2.105.0` according to the core changelog, so people with older versions of core will get a template error.

I'm setting it to the latest version now since it seems like a win, but we can roll that back to `2.105.0` if necessary. If so I'd think we should test to make sure that's the right one, which seems unnecessary when we can simply set to the current version when the new feature was added.