### PR TITLE
Allow seoGoogleTagManager property to be overridden from settings in data/local.js

### DIFF
--- a/views/body-snippet.html
+++ b/views/body-snippet.html
@@ -1,7 +1,9 @@
-{% if data.global.seoGoogleTagManager %}
+{% set seoOverRides = apos.settings.getOption('seoOverRides') %}
+{% set seoGoogleTagManager = seoOverRides.seoGoogleTagManager or data.global.seoGoogleTagManager %}
+{% if seoGoogleTagManager %}
   <!-- Google Tag Manager (noscript) -->
   <noscript>
-    <iframe src="https://www.googletagmanager.com/ns.html?id={{data.global.seoGoogleTagManager}}"
+    <iframe src="https://www.googletagmanager.com/ns.html?id={{seoGoogleTagManager}}"
     height="0" width="0" style="display:none;visibility:hidden"></iframe>
   </noscript>
   <!-- End Google Tag Manager (noscript) -->

--- a/views/head-snippet.html
+++ b/views/head-snippet.html
@@ -1,9 +1,11 @@
-{% if data.global.seoGoogleTagManager %}
+{% set seoOverRides = apos.settings.getOption('seoOverRides') %}
+{% set seoGoogleTagManager = seoOverRides.seoGoogleTagManager or data.global.seoGoogleTagManager %}
+{% if seoGoogleTagManager %}
   <!-- Google Tag Manager -->
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','{{data.global.seoGoogleTagManager}}');</script>
+  })(window,document,'script','dataLayer','{{seoGoogleTagManager}}');</script>
   <!-- End Google Tag Manager -->
 {% endif %}


### PR DESCRIPTION
Sample solution to close #50

Allow seoGoogleTagManager property to be overridden from settings in data/local.js such that specific Google Tag Managers can be enforced in specific environments i.e. dev/test

I've set this up to use a generic 'settings' module as discussed at [here ](https://docs.apostrophecms.org/core-concepts/global-settings/settings.html#changing-the-value-for-a-specific-server-only) but it could presumably just as easily be included in an apostrophe-global section (in line with the existing directives) or an apostrophe-seo section to keep the functionality together?