### PR TITLE
adds possibility to set headers in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.5.0 (2021-05-12)
-- Adds possibility to padd headers in config, if requesting the page need authentication.
+- Adds possibility to set headers in config, if requesting the page needs authentication.
 
 ## 1.4.1 (2021-03-24)
 - Adds a peer dependency for `apostrophe^2.116.1` to support the latest SEO page scan feature.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.0 (2021-05-12)
+- Adds possibility to padd headers in config, if requesting the page need authentication.
+
 ## 1.4.1 (2021-03-24)
 - Adds a peer dependency for `apostrophe^2.116.1` to support the latest SEO page scan feature.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you need authentication to access your website, you can also pass headers to 
       },
       minWordsOnPage: 400
     },
-    headers: {
+    scanHeaders: {
       // Passing some headers if necessary
     }
   }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Also, keep in mind that, when accessing the modal, your current url must match t
 
 Some of the rules can be configured from your `apostrophe-seo` declaration.
 
+If you need authentication to access your website, you can also pass headers to the config.
+
 ```js
   'apostrophe-seo': {
     scanRules: {
@@ -92,6 +94,9 @@ Some of the rules can be configured from your `apostrophe-seo` declaration.
         max: 80
       },
       minWordsOnPage: 400
+    },
+    headers: {
+      // Passing some headers here if necessary
     }
   }
 ```

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you need authentication to access your website, you can also pass headers to 
       minWordsOnPage: 400
     },
     headers: {
-      // Passing some headers here if necessary
+      // Passing some headers if necessary
     }
   }
 ```

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -14,8 +14,8 @@ module.exports = function (self, options) {
       try {
         const isDraft = req.locale.endsWith('-draft');
         const { href } = req.body;
-        const headers = typeof options.headers === 'object'
-          ? options.headers
+        const headers = typeof options.scanHeaders === 'object'
+          ? options.scanHeaders
           : {};
 
         const baseUrl = self.apos.pages.getBaseUrl(req);

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -26,8 +26,8 @@ module.exports = function (self, options) {
 
         const { data } = await axios.get(href, {
           headers: {
-            ...headers,
-            cookie: req.headers.cookie
+            cookie: req.headers.cookie,
+            ...headers
           }
         });
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -14,6 +14,9 @@ module.exports = function (self, options) {
       try {
         const isDraft = req.locale.endsWith('-draft');
         const { href } = req.body;
+        const headers = typeof options.headers === 'object'
+          ? options.headers
+          : {};
 
         const baseUrl = self.apos.pages.getBaseUrl(req);
 
@@ -23,6 +26,7 @@ module.exports = function (self, options) {
 
         const { data } = await axios.get(href, {
           headers: {
+            ...headers,
             cookie: req.headers.cookie
           }
         });


### PR DESCRIPTION
For protected environments, like staging, review, etc.. We need authentication to request the page and internal links in order to scan it.