### PR TITLE
add seo permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## next
 
-- Add `seo` permission to fine tune access to the page scan for non `admin` users
+- Add `admin-seo` permission to fine tune access to the page scan feature for non `admin` users.
 
 ## 1.5.0 (2021-05-12)
 - Adds possibility to set headers in config, if requesting the page needs authentication.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+- Add `seo` permission to fine tune access to the page scan for non `admin` users
+
 ## 1.5.0 (2021-05-12)
 - Adds possibility to set headers in config, if requesting the page needs authentication.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## next
 
-- Add `admin-seo` permission to fine tune access to the page scan feature for non `admin` users.
+- Add `admin-seo-page-scan` permission to fine tune access to the SEO page scan feature for non `admin` users.
 
 ## 1.5.0 (2021-05-12)
 - Adds possibility to set headers in config, if requesting the page needs authentication.

--- a/index.js
+++ b/index.js
@@ -34,5 +34,6 @@ module.exports = {
     self.prependSnippets();
     self.addRoutes();
     self.pushCreateSingleton();
+    self.addPermissions();
   }
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -188,7 +188,7 @@ module.exports = (self, { scanRules }) => {
   };
 
   self.addPermissions = function() {
-console.log('>>>>> adding SEO permission')
+    // only grants the ability to use the SEO scan button, not the ability to, say, edit just the SEO fields
     self.apos.permissions.add({
       value: 'admin-seo',
       label: 'SEO'

--- a/lib/api.js
+++ b/lib/api.js
@@ -190,7 +190,7 @@ module.exports = (self, { scanRules }) => {
   self.addPermissions = function() {
     // only grants the ability to use the SEO scan button, not the ability to, say, edit just the SEO fields
     self.apos.permissions.add({
-      value: 'admin-seo',
+      value: 'admin-seo-page-scan',
       label: 'SEO'
     });
   };

--- a/lib/api.js
+++ b/lib/api.js
@@ -186,4 +186,12 @@ module.exports = (self, { scanRules }) => {
 
     return deadLinks;
   };
+
+  self.addPermissions = function() {
+console.log('>>>>> adding SEO permission')
+    self.apos.permissions.add({
+      value: 'admin-seo',
+      label: 'SEO'
+    });
+  };
 };

--- a/lib/api.js
+++ b/lib/api.js
@@ -188,7 +188,7 @@ module.exports = (self, { scanRules }) => {
   };
 
   self.addPermissions = function() {
-    // only grants the ability to use the SEO scan button, not the ability to, say, edit just the SEO fields
+    // only grants the ability to use the SEO page scan button, not the ability to, say, edit just the SEO fields
     self.apos.permissions.add({
       value: 'admin-seo-page-scan',
       label: 'SEO'

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 module.exports = function (self, options) {
   self.addRoutes = function() {
     self.route('post', 'page-scan-modal', async (req, res) => {
-      if (!self.apos.permissions.can(req, 'admin-seo')) {
+      if (!self.apos.permissions.can(req, 'admin-seo-page-scan')) {
         return res.status(403).send('forbidden');
       }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 module.exports = function (self, options) {
   self.addRoutes = function() {
     self.route('post', 'page-scan-modal', async (req, res) => {
-      if (!self.apos.permissions.can(req, 'admin')) {
+      if (!(self.apos.permissions.can(req, 'admin') || self.apos.permissions.can(req, 'seo'))) {
         return res.status(403).send('forbidden');
       }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 module.exports = function (self, options) {
   self.addRoutes = function() {
     self.route('post', 'page-scan-modal', async (req, res) => {
-      if (!(self.apos.permissions.can(req, 'admin') || self.apos.permissions.can(req, 'seo'))) {
+      if (!(self.apos.permissions.can(req, 'admin') || self.apos.permissions.can(req, 'admin-seo'))) {
         return res.status(403).send('forbidden');
       }
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -3,7 +3,7 @@ const axios = require('axios');
 module.exports = function (self, options) {
   self.addRoutes = function() {
     self.route('post', 'page-scan-modal', async (req, res) => {
-      if (!(self.apos.permissions.can(req, 'admin') || self.apos.permissions.can(req, 'admin-seo'))) {
+      if (!self.apos.permissions.can(req, 'admin-seo')) {
         return res.status(403).send('forbidden');
       }
 


### PR DESCRIPTION
Allow non `admin` users to access the SEO tools without granting full access to sensitive admin only features